### PR TITLE
Added support for collection options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This helper can be used to reactively publish the results of an aggregation.
 - `pipeline` is the aggregation pipeline to execute.
 - `options` provides further options:
   - `observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
+  - `observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
   If none is given any change to the collection will cause the aggregation to be reevaluated.
   - `clientCollection` defaults to `collection._name` but can be overriden to sent the results
   to a different client-side collection. 

--- a/aggregate.js
+++ b/aggregate.js
@@ -1,6 +1,7 @@
 ReactiveAggregate = function (sub, collection, pipeline, options) {
   var defaultOptions = {
     observeSelector: {},
+    observeOptions: {},
     clientCollection: collection._name
   };
   options = _.extend(defaultOptions, options);
@@ -31,7 +32,7 @@ ReactiveAggregate = function (sub, collection, pipeline, options) {
   }
 
   // track any changes on the collection used for the aggregation
-  var query = collection.find(options.observeSelector);
+  var query = collection.find(options.observeSelector, options.observeOptions);
   var handle = query.observeChanges({
     added: update,
     changed: update,


### PR DESCRIPTION
We're entering optimization phase of our application, and most optimizations have included limiting fields being returned from our composeIO instance.

When field limiting, only the fields that you have asked for will trigger changes when they are changed. Other fields will be ignored.
