### PR TITLE
simplify multiple collection reactivity and add throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,50 +7,116 @@ Reactively publish aggregations.
 This helper can be used to reactively publish the results of an aggregation.
 
 ## Usage
-    ReactiveAggregate(sub, collection, pipeline, options)
+    ReactiveAggregate(subscription, collection, pipeline[, options])
 
-- `sub` should always be `this` in a publication.
+- `subscription` should always be `this` in a publication.
 - `collection` is the Mongo.Collection instance to query.
 - `pipeline` is the aggregation pipeline to execute.
 - `options` provides further options:
-  - `observeCollections` array of collections for observe, by default set `collection`.
-  - `observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
-  (e.g. `{ authorId: { $exists: 1 } }`)
+  - `observeSelector` can be given to improve efficiency. This selector is used for observing the reactive collections. If you wish to have different selectors for multiple reactive collections, use `lookupCollections` options.
   - `observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
+  - `lookupCollections` is keyed by your `$lookup.from` collection name(s). it takes `observeSelector` and `observeOptions` parameters. see example below.
   If none is given any change to the collection will cause the aggregation to be reevaluated.
-  (e.g. `{ limit: 10, sort: { createdAt: -1 } }`)
-  - `clientCollection` defaults to `collection._name` but can be overriden to sent the results
-  to a different client-side collection. 
 
-### Multiple collections observe
+### Examples
+  `options` applied to the **default** collection
+  ```
+  const options = {
+      observeSelector: {
+          bookId: { $exists: true },
+      },
+      observeOptions: {
+          limit: 10,
+          sort: { createdAt: -1 },
+      }
+  };
+  ```
+  `options` applied to all **$lookup** reactive collections
+  ```
+  const options = {
+      lookupCollections: {
+          'books': {
+             observeSelector: {
+                'releaseDate', { $gte: new Date('2010-01-01') }
+             },
+             observeOptions: {
+                 limit: 10,
+                 sort: { createdAt: -1 },
+             }
+          }
+      }
+  };
+  ```
 
-- `options`:
-  - `observeCollections` can be array of collections;
-  - `observeSelector` can be array of selectors;
-  - `observeOptions` can be array of observe options.
+  - `clientCollection` defaults to `collection._name` but can be overriden to sent the results to a different client-side collection.
 
-See [example for observing multiple collections](#multiple-collections-observe-example).
+
+## Multiple collections observe
+By default, any collection instances passed into the aggregation pipeline as a `Mongo.Collection` instance will be reactive. If you wish to opt out of reactivity for a collection in your pipeline, simply pass the `Collection._name` as a string.
+
+### Example
+All collections reactive:
+```
+const pipeline = [{
+    $lookup: {
+        from: Books,
+        localField: 'bookId',
+        foreignField: '_id',
+        as: 'books',
+    },
+    ...
+    $lookup: {
+        from: Authors,
+        localField: 'authorId',
+        foreignField: '_id',
+        as: 'authors',
+    },
+    ...
+}];
+```
+
+Only `Books` collection is reactive:
+```
+const pipeline = [{
+    $lookup: {
+        from: Books,
+        localField: 'bookId',
+        foreignField: '_id',
+        as: 'books',
+    },
+    ...
+    $lookup: {
+        from: Authors._name,
+        localField: 'authorId',
+        foreignField: '_id',
+        as: 'authors',
+    },
+    ...
+}];
+```
 
 ## Quick Example
 
 A publication for one of the
 [examples](https://docs.mongodb.org/v3.0/reference/operator/aggregation/group/#group-documents-by-author)
 in the MongoDB docs would look like this:
-
-    Meteor.publish("booksByAuthor", function () {
-      ReactiveAggregate(this, Books, [{
-        $group: {
-          _id: "$author",
-          books: { $push: "$$ROOT" }
-        }
-      }]);
-    });
+```
+Meteor.publish("booksByAuthor", function () {
+    ReactiveAggregate(this, Books, [{
+    $group: {
+        _id: "$author",
+        books: { $push: "$$ROOT" }
+    }
+    }]);
+});
+```
 
 ## Extended Example
 
 Define the parent collection you want to run an aggregation on. Let's say:
-
-`Reports = new Meteor.Collection('Reports');`
+```
+Reports = new Meteor.Collection('Reports');
+```
 
 .. in a location where all your other collections are defined, say `lib/collections.js`
 
@@ -59,15 +125,15 @@ Next, prepare to publish the aggregation on the `Reports` collection into anothe
 Create the `clientReport` in the client side (its needed only for client use). This  collection will be the destination in which the aggregation will be put into upon completion.
 
 Now you publish the aggregation on the server:
-
-    Meteor.publish("reportTotals", function() {
+```
+Meteor.publish("reportTotals", function() {
     // Remember, ReactiveAggregate doesn't return anything
     ReactiveAggregate(this, Reports, [{
         // assuming our Reports collection have the fields: hours, books
         $group: {
             '_id': this.userId,
             'hours': {
-            // In this case, we're running summation. 
+            // In this case, we're running summation.
                 $sum: '$hours'
             },
             'books': {
@@ -76,53 +142,57 @@ Now you publish the aggregation on the server:
         }
     }, {
         $project: {
-        	// an id can be added here, but when omitted, 
+            // an id can be added here, but when omitted,
             // it is created automatically on the fly for you
             hours: '$hours',
             books: '$books'
         } // Send the aggregation to the 'clientReport' collection available for client use
     }], { clientCollection: "clientReport" });
-    });
-    
-We therefore need to subscribe to the above Publish.
+});
+```
 
-`Meteor.subscribe("reportTotals");`
+We therefore need to subscribe to the above Publish.
+```
+Meteor.subscribe("reportTotals");
+```
 
 Then in our Template helper:
-
-    Template.statsBrief.helpers({
-        reportTotals: function() {
-            console.log("I'm working");
-            return clientReport.find();
-        },
-    });
+```
+Template.statsBrief.helpers({
+    reportTotals: function() {
+        console.log("I'm working");
+        return clientReport.find();
+    },
+});
+```
 
 Finally, your template:
-
-    {{#each reportTotals}}Total Hours: {{hours}} <br/>Total Books: {{books}}{{/each}}
+```
+{{#each reportTotals}}Total Hours: {{hours}} <br/>Total Books: {{books}}{{/each}}
+```
 
 Your aggregated values will therefore be available in client-side and behave reactively just as you'd expect.
 
 Enjoy aggregating `reactively`!
 
 ## Multiple collections observe example
-
-
-    Meteor.publish("booksByAuthor", function () {
-      ReactiveAggregate(this, Books, [{
-        $group: {
-          _id: "$author",
-          books: { $push: "$$ROOT" }
+```
+Meteor.publish("booksByAuthor", function () {
+    ReactiveAggregate(this, Books, [{
+    $group: {
+        _id: "$author",
+        books: { $push: "$$ROOT" }
+    }
+    }], {
+    observeSelector: {
+        `${Books._name}`: {
+            authorId: { $exists: true },
         }
-      }], {
-        observeCollections: [
-          Books,
-          Authors
-        ],
-        observeSelector: [
-          { authorId: { $exists: 1 } } // for Books
-          // for Authors get default: {}
-        ],
-        // observeOptions: // for Books and Authors get {}
-      );
-    });
+    }, // for Books
+        // for Authors get default: {}
+    // observeOptions: {} <- default: all reactive collections get no query options
+    );
+});
+```
+
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This helper can be used to reactively publish the results of an aggregation.
 - `options` provides further options:
   - `observeSelector` can be given to improve efficiency. This selector is used for observing the reactive collections. If you wish to have different selectors for multiple reactive collections, use `lookupCollections` options.
   - `observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
+  - `delay` (default: `250`) the time (in milliseconds) between re-runs caused by changes in any reactive collections in the aggregation.
   - `lookupCollections` is keyed by your `$lookup.from` collection name(s). it takes `observeSelector` and `observeOptions` parameters. see example below.
   If none is given any change to the collection will cause the aggregation to be reevaluated.
 

--- a/aggregate.js
+++ b/aggregate.js
@@ -1,99 +1,103 @@
-ReactiveAggregate = function (sub, collection, pipeline, options) {
-  var defaultOptions = {
-    observeCollections: collection,
-    observeSelector: {},
-    observeOptions: {},
-    clientCollection: collection._name
-  };
-  options = _.extend(defaultOptions, options);
+import { Mongo } from 'meteor/mongo';
 
-  var initializing = true;
-  sub._ids = {};
-  sub._iteration = 1;
+const defaultOptions = ({
+  collection, options
+}) => ({
+  observeSelector: {},
+  observeOptions: {},
+  lookupCollections: {},
+  clientCollection: collection._name,
+  ...options
+});
 
-  function update() {
-    if (initializing) return;
-    // add and update documents on the client
-    collection.aggregate(pipeline).forEach(function (doc) {
-      if (!sub._ids[doc._id]) {
-        sub.added(options.clientCollection, doc._id, doc);
-      } else {
-        sub.changed(options.clientCollection, doc._id, doc);
-      }
-      sub._ids[doc._id] = sub._iteration;
-    });
-    // remove documents not in the result anymore
-    _.forEach(sub._ids, function (v, k) {
-      if (v != sub._iteration) {
-        delete sub._ids[k];
-        sub.removed(options.clientCollection, k);
-      }
-    });
-    sub._iteration++;
-  }
+export const ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
+  // fill out default options
+  const {
+    observeSelector, observeOptions, lookupCollections, clientCollection
+  } = defaultOptions({
+    collection,
+    options
+  });
 
-  // track any changes on the collection used for the aggregation
-  if (!Array.isArray(options.observeCollections)) {
-    // Make array
-    var arr = [];
-    arr.push(options.observeCollections);
-    options.observeCollections = arr;
-  }
-  // Create observers
-  /**
-   * @type {Meteor.LiveQueryHandle[]|*}
-   */
-  var handles = options.observeCollections.map( createObserver );
+  // don't update the subscription until __after__ the initial hydrating of our collection
+  let initializing = true;
+  // mutate the subscription to ensure it updates as we version it
+  subscription._ids = {};
+  subscription._iteration = 1;
 
-  /**
-   * Create observer
-   * @param {Mongo.Collection|*} collection
-   * @param {number} i
-   * @returns {any|*|Meteor.LiveQueryHandle} Handle
-   */
-  function createObserver( collection, i) {
-    var observeSelector = getObjectFrom(options.observeOptions, i);
-    var observeOptions = getObjectFrom(options.observeOptions, i);
-    var query = collection.find(observeSelector, observeOptions);
-    return handle = query.observeChanges({
-      added: update,
-      changed: update,
-      removed: update,
-      error: function (err) {
-        throw err;
-      }
-    });
+  // create a list of collections to watch and make sure
+  // we create a sanitized "strings-only" version of our pipeline
+  const observerHandles = [createObserver(collection, { observeSelector, observeOptions })];
+  // look for $lookup collections passed in as Mongo.Collection instances
+  // and create observers for them
+  // if any $lookup.from stages are passed in as strings they will be omitted
+  // from this process. the aggregation will still work, but those collections
+  // will not force an update to this query if changed.
+  const safePipeline = pipeline.map((stage) => {
+    if (stage.$lookup && stage.$lookup.from instanceof Mongo.Collection) {
+      const collection = stage.$lookup.from;
+      observerHandles.push(createObserver(collection, lookupCollections[collection._name]));
+      return {
+        ...stage,
+        $lookup: {
+          ...stage.$lookup,
+          from: collection._name
+        }
+      };
+    }
+    return stage;
+  });
 
-  }
-
-  /**
-   * Get object from array or just object
-   * @param {Object|[]} variable
-   * @param i
-   * @returns {{}}
-   */
-  function getObjectFrom(variable, i) {
-    return Array.isArray(variable)
-      ? (
-        typeof variable[i] !== 'undefined'
-          ? variable[i]
-          : {}
-      )
-      : variable;
-  }
-  
   // observeChanges() will immediately fire an "added" event for each document in the query
   // these are skipped using the initializing flag
   initializing = false;
   // send an initial result set to the client
   update();
   // mark the subscription as ready
-  sub.ready();
-
+  subscription.ready();
   // stop observing the cursor when the client unsubscribes
-  sub.onStop(function () {
-    handles.map(function (handle) {
-      handle.stop();
+  subscription.onStop(() => observerHandles.map((handle) => handle.stop()));
+
+  function update() {
+    if (initializing) {
+      return;
+    }
+    // add and update documents on the client
+    collection.aggregate(safePipeline).forEach((doc) => {
+      if (!subscription._ids[doc._id]) {
+        subscription.added(clientCollection, doc._id, doc);
+      } else {
+        subscription.changed(clientCollection, doc._id, doc);
+      }
+      subscription._ids[doc._id] = subscription._iteration;
     });
-  });
+    // remove documents not in the result anymore
+    _.each(subscription._ids, (iteration, key) => {
+      if (iteration != subscription._iteration) {
+        delete subscription._ids[key];
+        subscription.removed(clientCollection, key);
+      }
+    });
+    subscription._iteration++;
+  }
+
+  /**
+	 * Create observer
+	 * @param {Mongo.Collection|*} collection
+	 * @returns {any|*|Meteor.LiveQueryHandle} Handle
+	 */
+  function createObserver(collection, options) {
+    const { observeSelector, observeOptions } = options;
+    const selector = observeSelector || {};
+    const options = observeOptions || {};
+    const query = collection.find(selector, options);
+    return query.observeChanges({
+      added: update,
+      changed: update,
+      removed: update,
+      error: (err) => {
+        throw err;
+      }
+    });
+  }
 };

--- a/aggregate.js
+++ b/aggregate.js
@@ -87,8 +87,8 @@ export const ReactiveAggregate = function (subscription, collection, pipeline = 
 	 * @param {Mongo.Collection|*} collection
 	 * @returns {any|*|Meteor.LiveQueryHandle} Handle
 	 */
-  function createObserver(collection, options) {
-    const { observeSelector, observeOptions } = options;
+  function createObserver(collection, queryOptions) {
+    const { observeSelector, observeOptions } = queryOptions;
     const selector = observeSelector || {};
     const options = observeOptions || {};
     const query = collection.find(selector, options);

--- a/aggregate.js
+++ b/aggregate.js
@@ -87,7 +87,7 @@ export const ReactiveAggregate = function (subscription, collection, pipeline = 
 	 * @param {Mongo.Collection|*} collection
 	 * @returns {any|*|Meteor.LiveQueryHandle} Handle
 	 */
-  function createObserver(collection, queryOptions) {
+  function createObserver(collection, queryOptions = {}) {
     const { observeSelector, observeOptions } = queryOptions;
     const selector = observeSelector || {};
     const options = observeOptions || {};

--- a/mongo-collection-aggregate.js
+++ b/mongo-collection-aggregate.js
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+
+Mongo.Collection.prototype.aggregate = function(pipeline, options) {
+  const collection = this.rawCollection();
+  return Meteor.wrapAsync(collection.aggregate.bind(collection))(pipeline, options);
+}

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "jcbernack:reactive-aggregate",
-  version: "0.8.0",
+  version: "1.0.0",
   // Brief, one-line summary of the package.
   summary: "Reactively publish aggregations.",
   // URL to the Git repository containing the source code for this package.
@@ -11,10 +11,9 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom("1.2.1");
-  api.use("underscore");
-  api.use("mongo");
-  api.use("meteorhacks:aggregate@1.3.0");
-  api.addFiles("aggregate.js");
-  api.export("ReactiveAggregate");
+  api.versionsFrom("1.5");
+  api.use(['ecmascript', 'underscore', 'mongo']);
+
+  api.addFiles("./mongo-collection-aggregate.js");
+  api.mainModule("./aggregate.js");
 });


### PR DESCRIPTION
highlights:
- package will automatically make `$lookup.from` collections reactive if they're passed in as an instance of `Mongo.Collection` (string collection names will _not_ be reactive)
- added `aggregate` to `Mongo.Collection.prototype` à la `meteorhacks.aggregate`, removing that dependency
- used modern js language features to simplify the codebase
- added `_.throttle` option as described by @jedwards1211
- updated docs to reflect changes