### PR TITLE
noReady functionality for publish

### DIFF
--- a/aggregate.js
+++ b/aggregate.js
@@ -13,7 +13,7 @@ const defaultOptions = ({
   ...options
 });
 
-export default ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
+const ReactiveAggregate = function(subscription, collection, pipeline = [], options = {}) {
   // fill out default options
   const {
     observeSelector, observeOptions, delay, lookupCollections, clientCollection
@@ -21,7 +21,7 @@ export default ReactiveAggregate = function (subscription, collection, pipeline 
     collection,
     options
   });
-
+  
   // run, or re-run, the aggregation pipeline
   const throttledUpdate = _.throttle(Meteor.bindEnvironment(() => {
     // add and update documents on the client
@@ -43,13 +43,13 @@ export default ReactiveAggregate = function (subscription, collection, pipeline 
     subscription._iteration++;
   }), delay);
   const update = () => !initializing ? throttledUpdate() : null;
-
+  
   // don't update the subscription until __after__ the initial hydrating of our collection
   let initializing = true;
   // mutate the subscription to ensure it updates as we version it
   subscription._ids = {};
   subscription._iteration = 1;
-
+  
   // create a list of collections to watch and make sure
   // we create a sanitized "strings-only" version of our pipeline
   const observerHandles = [createObserver(collection, { observeSelector, observeOptions })];
@@ -72,7 +72,7 @@ export default ReactiveAggregate = function (subscription, collection, pipeline 
     }
     return stage;
   });
-
+  
   // observeChanges() will immediately fire an "added" event for each document in the query
   // these are skipped using the initializing flag
   initializing = false;
@@ -82,12 +82,12 @@ export default ReactiveAggregate = function (subscription, collection, pipeline 
   if (!options.noReady) subscription.ready();
   // stop observing the cursor when the client unsubscribes
   subscription.onStop(() => observerHandles.map((handle) => handle.stop()));
-
+  
   /**
-	 * Create observer
-	 * @param {Mongo.Collection|*} collection
-	 * @returns {any|*|Meteor.LiveQueryHandle} Handle
-	 */
+  * Create observer
+  * @param {Mongo.Collection|*} collection
+  * @returns {any|*|Meteor.LiveQueryHandle} Handle
+  */
   function createObserver(collection, queryOptions = {}) {
     const { observeSelector, observeOptions } = queryOptions;
     const selector = observeSelector || {};
@@ -103,3 +103,5 @@ export default ReactiveAggregate = function (subscription, collection, pipeline 
     });
   }
 };
+
+export default ReactiveAggregate;

--- a/aggregate.js
+++ b/aggregate.js
@@ -9,10 +9,11 @@ const defaultOptions = ({
   delay: 250,
   lookupCollections: {},
   clientCollection: collection._name,
+  noReady: false,
   ...options
 });
 
-export const ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
+export default ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
   // fill out default options
   const {
     observeSelector, observeOptions, delay, lookupCollections, clientCollection
@@ -78,7 +79,7 @@ export const ReactiveAggregate = function (subscription, collection, pipeline = 
   // send an initial result set to the client
   update();
   // mark the subscription as ready
-  subscription.ready();
+  if (!options.noReady) subscription.ready();
   // stop observing the cursor when the client unsubscribes
   subscription.onStop(() => observerHandles.map((handle) => handle.stop()));
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "jcbernack:reactive-aggregate",
-  version: "1.0.0",
+  version: "1.0.1",
   // Brief, one-line summary of the package.
   summary: "Reactively publish aggregations.",
   // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
Added `noReady: true` option to options variable allowing optional ready state to allow for in-publish aggregation similar to `tmeasday:publish-counts`. 

Example use: eCommerce store listing products, aggregation to get distinct `brand` field for filtering using the existing search keywords or product category/other filters selected.

Also modified export to default export to allow for use of 

`import ReactiveAggregate from 'meteor/jcbernack:reactive-aggregate'`

instead of 

`import { ReactiveAggregate } from 'meteor/jcbernack:reactive-aggregate'`

as there are no other variables for importing from this package.

```
Meteor.publish('search', function(query, limit, skip) {
        let filter = _buildSearchQuery(query.keyword)
       
        var data = Products.find(filter, {limit, skip})
        
        Meteor.defer(() => {
            ReactiveAggregate(this, Products, [
                { $match: filter },
                { $group: { _id: '$brand', count: { $sum: 1 } } }
            ], { clientCollection: 'filterBrand', noReady: true })

            ReactiveAggregate(this, Products, [
                { $match: filter },
                { $group: { _id: '$category_id', count: { $sum: 1 } } }
            ], { clientCollection: 'filterCategories', noReady: true })
        })

        Counts.publish(this, "searchCount", Products.find(filter), {noReady: true})
        
        return data
    } else {
        this.stop()
    }
})
```
