### PR TITLE
Updated to work with Meteor 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Reactively publish aggregations.
 This helper can be used to reactively publish the results of an aggregation.
 
 ## Usage
+    import ReactiveAggregate from 'meteor/jcbernack:reactive-aggregate';
+    
     ReactiveAggregate(subscription, collection, pipeline[, options])
 
 - `subscription` should always be `this` in a publication.

--- a/aggregate.js
+++ b/aggregate.js
@@ -12,7 +12,7 @@ const defaultOptions = ({
   ...options
 });
 
-export const ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
+ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
   // fill out default options
   const {
     observeSelector, observeOptions, delay, lookupCollections, clientCollection

--- a/aggregate.js
+++ b/aggregate.js
@@ -12,7 +12,7 @@ const defaultOptions = ({
   ...options
 });
 
-ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
+export default ReactiveAggregate = function (subscription, collection, pipeline = [], options = {}) {
   // fill out default options
   const {
     observeSelector, observeOptions, delay, lookupCollections, clientCollection

--- a/mongo-collection-aggregate.js
+++ b/mongo-collection-aggregate.js
@@ -1,7 +1,0 @@
-import { Meteor } from 'meteor/meteor';
-import { Mongo } from 'meteor/mongo';
-
-Mongo.Collection.prototype.aggregate = function(pipeline, options) {
-  const collection = this.rawCollection();
-  return Meteor.wrapAsync(collection.aggregate.bind(collection))(pipeline, options);
-}

--- a/package.js
+++ b/package.js
@@ -1,19 +1,19 @@
 Package.describe({
-  name: "jcbernack:reactive-aggregate",
-  version: "1.0.0",
+  name: 'jcbernack:reactive-aggregate',
+  version: '1.1.0',
   // Brief, one-line summary of the package.
   summary: "Reactively publish aggregations.",
   // URL to the Git repository containing the source code for this package.
-  git: "https://github.com/JcBernack/meteor-reactive-aggregate",
+  git: 'https://github.com/JcBernack/meteor-reactive-aggregate',
   // By default, Meteor will default to using README.md for documentation.
   // To avoid submitting documentation, set this field to null.
-  documentation: "README.md"
+  documentation: 'README.md'
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom("1.5");
-  api.use(['ecmascript', 'underscore', 'mongo']);
+  api.versionsFrom('1.5');
+  api.use(['ecmascript', 'underscore', 'mongo', 'sakulstra:aggregate@1.4.3'], ['server']);
 
-  api.addFiles("./mongo-collection-aggregate.js");
-  api.mainModule("./aggregate.js");
+  api.export('ReactiveAggregate', 'server');
+  api.mainModule('aggregate.js', 'server');
 });

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'jcbernack:reactive-aggregate',
   version: '1.1.0',
   // Brief, one-line summary of the package.
-  summary: "Reactively publish aggregations.",
+  summary: 'Reactively publish aggregations.',
   // URL to the Git repository containing the source code for this package.
   git: 'https://github.com/JcBernack/meteor-reactive-aggregate',
   // By default, Meteor will default to using README.md for documentation.
@@ -14,6 +14,5 @@ Package.onUse(function(api) {
   api.versionsFrom('1.5');
   api.use(['ecmascript', 'underscore', 'mongo', 'sakulstra:aggregate@1.4.3'], ['server']);
 
-  api.export('ReactiveAggregate', 'server');
   api.mainModule('aggregate.js', 'server');
 });


### PR DESCRIPTION
Meteor 1.7 uses the new 3.x version of the MongoDB driver (see meteor/meteor#9936).

Have added the [sakulstra:aggregate](https://github.com/sakulstra/meteor-aggregate) package as a dependency to handle extending the Mongo.Collection prototype.